### PR TITLE
fix: Retorna nome do usuario em resposta de rota de login

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/LoginResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/LoginResponseDTO.java
@@ -1,7 +1,6 @@
 package com.pointtils.pointtils.src.application.dto.responses;
 
 import com.pointtils.pointtils.src.application.dto.TokensDTO;
-import com.pointtils.pointtils.src.application.dto.UserDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,7 +16,7 @@ public class LoginResponseDTO {
     String message;
     Data data;
 
-    public record Data(UserDTO user, TokensDTO tokens) {
+    public record Data(UserLoginResponseDTO user, TokensDTO tokens) {
 
     }
 }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/UserLoginResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/UserLoginResponseDTO.java
@@ -1,0 +1,23 @@
+package com.pointtils.pointtils.src.application.dto.responses;
+
+import com.pointtils.pointtils.src.core.domain.entities.enums.UserStatus;
+import com.pointtils.pointtils.src.core.domain.entities.enums.UserTypeE;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLoginResponseDTO {
+
+    private UUID id;
+    private String name;
+    private String email;
+    private String phone;
+    private String picture;
+    private UserTypeE type;
+    private UserStatus status;
+}

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/AuthService.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/AuthService.java
@@ -1,18 +1,18 @@
 package com.pointtils.pointtils.src.application.services;
-import com.pointtils.pointtils.src.core.domain.entities.enums.UserStatus;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
+
+import com.pointtils.pointtils.src.application.dto.TokensDTO;
 import com.pointtils.pointtils.src.application.dto.responses.LoginResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.RefreshTokenResponseDTO;
-import com.pointtils.pointtils.src.application.dto.TokensDTO;
-import com.pointtils.pointtils.src.application.dto.UserDTO;
+import com.pointtils.pointtils.src.application.dto.responses.UserLoginResponseDTO;
 import com.pointtils.pointtils.src.core.domain.entities.User;
+import com.pointtils.pointtils.src.core.domain.entities.enums.UserStatus;
 import com.pointtils.pointtils.src.core.domain.exceptions.AuthenticationException;
 import com.pointtils.pointtils.src.infrastructure.configs.JwtService;
 import com.pointtils.pointtils.src.infrastructure.configs.MemoryBlacklistService;
 import com.pointtils.pointtils.src.infrastructure.repositories.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -56,13 +56,14 @@ public class AuthService {
         String accessToken = jwtTokenProvider.generateToken(user.getEmail());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
 
-        UserDTO userDTO = new UserDTO(
-        user.getId(), 
-        user.getEmail(),
-        user.getPhone(),
-        user.getPicture(),
-        user.getType(),
-        user.getStatus()
+        UserLoginResponseDTO userDTO = new UserLoginResponseDTO(
+                user.getId(),
+                user.getDisplayName(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getPicture(),
+                user.getType(),
+                user.getStatus()
         );
 
         TokensDTO tokensDTO = new TokensDTO(

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Enterprise.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Enterprise.java
@@ -31,7 +31,6 @@ public class Enterprise extends User {
 
     @Override
     public UserTypeE getType() {
-
         return UserTypeE.ENTERPRISE;
     }
 }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/AuthControllerTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/AuthControllerTest.java
@@ -1,9 +1,9 @@
 package com.pointtils.pointtils.src.application.controllers;
 
+import com.pointtils.pointtils.src.application.dto.TokensDTO;
 import com.pointtils.pointtils.src.application.dto.responses.LoginResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.RefreshTokenResponseDTO;
-import com.pointtils.pointtils.src.application.dto.TokensDTO;
-import com.pointtils.pointtils.src.application.dto.UserDTO;
+import com.pointtils.pointtils.src.application.dto.responses.UserLoginResponseDTO;
 import com.pointtils.pointtils.src.application.services.AuthService;
 import com.pointtils.pointtils.src.core.domain.entities.Enterprise;
 import com.pointtils.pointtils.src.core.domain.entities.Person;
@@ -97,12 +97,14 @@ class AuthControllerTest {
                 true,
                 "Autenticação realizada com sucesso",
                 new LoginResponseDTO.Data(
-                                 new UserDTO(
-                                                        UUID.randomUUID(), "usuario@exemplo.com",
-                                                        null,
-                                                        null,
-                                                        UserTypeE.PERSON,
-                                                        UserStatus.ACTIVE),
+                        new UserLoginResponseDTO(
+                                UUID.randomUUID(),
+                                "João Silva",
+                                "usuario@exemplo.com",
+                                null,
+                                null,
+                                UserTypeE.PERSON,
+                                UserStatus.ACTIVE),
                         new TokensDTO("access-token", "refresh-token", "Bearer", 3600,
                                 604800)));
 
@@ -133,12 +135,14 @@ class AuthControllerTest {
                 true,
                 "Autenticação realizada com sucesso",
                 new LoginResponseDTO.Data(
-                                        new UserDTO(
-                                                        UUID.randomUUID(), "enterprise@exemplo.com",
-                                                        null,
-                                                        null,
-                                                        UserTypeE.ENTERPRISE,
-                                                        UserStatus.ACTIVE),
+                        new UserLoginResponseDTO(
+                                UUID.randomUUID(),
+                                "Empresa Exemplo",
+                                "enterprise@exemplo.com",
+                                null,
+                                null,
+                                UserTypeE.ENTERPRISE,
+                                UserStatus.ACTIVE),
                         new TokensDTO("access-token", "refresh-token", "Bearer", 3600,
                                 604800)));
 
@@ -286,12 +290,14 @@ class AuthControllerTest {
                 true,
                 "Autenticação realizada com sucesso",
                 new LoginResponseDTO.Data(
-                                 new UserDTO(
-                                                        UUID.randomUUID(), "usuario@exemplo.com",
-                                                        null,
-                                                        null,
-                                                        UserTypeE.PERSON,
-                                                        UserStatus.ACTIVE),
+                        new UserLoginResponseDTO(
+                                UUID.randomUUID(),
+                                "João Silva",
+                                "usuario@exemplo.com",
+                                null,
+                                null,
+                                UserTypeE.PERSON,
+                                UserStatus.ACTIVE),
                         new TokensDTO("access-token", "refresh-token", "Bearer", 3600,
                                 604800)));
 
@@ -382,14 +388,14 @@ class AuthControllerTest {
         when(authService.refreshToken(anyString()))
                 .thenThrow(new AuthenticationException("Usuário não encontrado"));
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/refresh")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .content("""
-                        {
-                            "refresh_token":"valid-but-user-not-found"
-                        }
-                        """))
+                        .post("/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "refresh_token":"valid-but-user-not-found"
+                                }
+                                """))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("Usuário não encontrado"));
     }
@@ -405,10 +411,10 @@ class AuthControllerTest {
         when(authService.logout(anyString(), anyString())).thenReturn(true);
 
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/logout")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshTokenJson))
+                        .post("/v1/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshTokenJson))
                 .andExpect(status().isOk());
     }
 
@@ -419,10 +425,10 @@ class AuthControllerTest {
         String refreshTokenJson = "{ \"refresh_token\": \"" + refreshToken + "\" }";
 
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/logout")
-                .header("Authorization", "Bearer ")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshTokenJson))
+                        .post("/v1/auth/logout")
+                        .header("Authorization", "Bearer ")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshTokenJson))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Access token não fornecido"));
     }
@@ -433,10 +439,10 @@ class AuthControllerTest {
         String accessToken = jwtTokenProvider.generateToken("user@exemplo.com");
         String refreshTokenJson = "{ \"refresh_token\": \"\" }";
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/logout")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshTokenJson))
+                        .post("/v1/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshTokenJson))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Refresh token não fornecido"));
     }
@@ -451,10 +457,10 @@ class AuthControllerTest {
                 .thenThrow(new AuthenticationException("Access token inválido ou expirado"));
 
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/logout")
-                .header("Authorization", "Bearer invalid-access-token")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshTokenJson))
+                        .post("/v1/auth/logout")
+                        .header("Authorization", "Bearer invalid-access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshTokenJson))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").value("Access token inválido ou expirado"));
     }
@@ -469,10 +475,10 @@ class AuthControllerTest {
                 .thenThrow(new AuthenticationException("Refresh token inválido ou expirado"));
 
         mockMvc.perform(MockMvcRequestBuilders
-                .post("/v1/auth/logout")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(refreshTokenJson))
+                        .post("/v1/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshTokenJson))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").value("Refresh token inválido ou expirado"));
     }


### PR DESCRIPTION
📍 Título

Corrige corpo de resposta da rota de login para retornar name

📌 Descrição

Se usuário for pessoa ou intérprete --> retorna campo name preenchido com nome pessoal
Se usuário for empresa --> retorna campo name preenchido com razão social

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🧪 Testes realizados:

Usuário empresa:
<img width="1421" height="725" alt="image" src="https://github.com/user-attachments/assets/84df2a76-5f12-42a0-a643-55cf419c0221" />

Usuário intérprete:
<img width="1409" height="911" alt="image" src="https://github.com/user-attachments/assets/d02a0e7f-ae73-4935-b174-e6199c8b227a" />

Usuário pessoa:
<img width="1410" height="912" alt="image" src="https://github.com/user-attachments/assets/0ee805c3-1acd-4c19-a2da-128db14267db" />

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Backend/issues/109