### PR TITLE
Ajusta filtro de appointments para retornar dados de contato

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/controllers/AppointmentController.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/controllers/AppointmentController.java
@@ -1,9 +1,18 @@
 package com.pointtils.pointtils.src.application.controllers;
 
-import java.util.List;
-import java.util.UUID;
-
+import com.pointtils.pointtils.src.application.dto.requests.AppointmentPatchRequestDTO;
+import com.pointtils.pointtils.src.application.dto.requests.AppointmentRequestDTO;
+import com.pointtils.pointtils.src.application.dto.responses.ApiResponse;
+import com.pointtils.pointtils.src.application.dto.responses.AppointmentFilterResponseDTO;
+import com.pointtils.pointtils.src.application.dto.responses.AppointmentResponseDTO;
+import com.pointtils.pointtils.src.application.services.AppointmentService;
+import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentModality;
+import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,18 +24,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.pointtils.pointtils.src.application.dto.requests.AppointmentPatchRequestDTO;
-import com.pointtils.pointtils.src.application.dto.requests.AppointmentRequestDTO;
-import com.pointtils.pointtils.src.application.dto.responses.ApiResponse;
-import com.pointtils.pointtils.src.application.dto.responses.AppointmentResponseDTO;
-import com.pointtils.pointtils.src.application.services.AppointmentService;
-import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentModality;
-import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentStatus;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1/appointments")
@@ -34,7 +34,7 @@ import lombok.AllArgsConstructor;
 @SecurityRequirement(name = "bearerAuth")
 @Tag(name = "Appointment Controller", description = "Endpoints para gerenciamento de solicitações de agendamento")
 public class AppointmentController {
-    
+
     private final AppointmentService appointmentService;
 
     @PostMapping
@@ -43,10 +43,10 @@ public class AppointmentController {
 
         AppointmentResponseDTO response = appointmentService.createAppointment(dto);
         ApiResponse<AppointmentResponseDTO> apiResponse =
-            ApiResponse.success("Solicitação criada com sucesso", response);
+                ApiResponse.success("Solicitação criada com sucesso", response);
         return ResponseEntity.ok(apiResponse);
     }
-    
+
     @GetMapping
     @Operation(summary = "Lista todos os agendamentos")
     public ResponseEntity<ApiResponse<List<AppointmentResponseDTO>>> findAll() {
@@ -64,7 +64,7 @@ public class AppointmentController {
     @PatchMapping("/{id}")
     @Operation(summary = "Atualiza parcialmente um agendamento por ID")
     public ResponseEntity<ApiResponse<AppointmentResponseDTO>> updatePartial(@PathVariable UUID id,
-                                                                            @RequestBody @Valid AppointmentPatchRequestDTO dto) {
+                                                                             @RequestBody @Valid AppointmentPatchRequestDTO dto) {
         AppointmentResponseDTO updated = appointmentService.updatePartial(id, dto);
         return ResponseEntity.ok(ApiResponse.success("Solicitação atualizada com sucesso", updated));
     }
@@ -76,24 +76,22 @@ public class AppointmentController {
         return ResponseEntity.noContent().build();
     }
 
-    /*Testar! */
     @GetMapping("/filter")
-    
     @Operation(summary = "Busca agendamentos com filtros opcionais")
-    public ResponseEntity<ApiResponse<List<AppointmentResponseDTO>>> searchAppointments(
-        @RequestParam(required = false) UUID interpreterId,
-        @RequestParam(required = false) UUID userId,
-        @RequestParam(required = false) AppointmentStatus status,
-        @RequestParam(required = false) AppointmentModality modality,
-        @RequestParam(required = false) String fromDateTime) {
-        
-        java.time.LocalDateTime from = null;
+    public ResponseEntity<ApiResponse<List<AppointmentFilterResponseDTO>>> searchAppointments(
+            @RequestParam(required = false) UUID interpreterId,
+            @RequestParam(required = false) UUID userId,
+            @RequestParam(required = false) AppointmentStatus status,
+            @RequestParam(required = false) AppointmentModality modality,
+            @RequestParam(required = false) String fromDateTime) {
+
+        LocalDateTime from = null;
         if (fromDateTime != null && !fromDateTime.trim().isEmpty()) {
-            from = java.time.LocalDateTime.parse(fromDateTime);
+            from = LocalDateTime.parse(fromDateTime);
         }
-        
-        List<AppointmentResponseDTO> appointments = appointmentService.searchAppointments(interpreterId, userId, status, modality, from);
+
+        List<AppointmentFilterResponseDTO> appointments = appointmentService.searchAppointments(interpreterId, userId, status, modality, from);
         return ResponseEntity.ok(ApiResponse.success("Solicitações encontradas com sucesso", appointments));
     }
-    
+
 }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/AppointmentFilterResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/AppointmentFilterResponseDTO.java
@@ -1,0 +1,19 @@
+package com.pointtils.pointtils.src.application.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentFilterResponseDTO extends AppointmentResponseDTO {
+
+    @JsonProperty("contact_data")
+    private ContactDataResponseDTO contactData;
+}

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/AppointmentResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/AppointmentResponseDTO.java
@@ -4,19 +4,19 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalTime;
 import java.util.UUID;
 
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AppointmentResponseDTO {
 
     private UUID id;

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/ContactDataResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/ContactDataResponseDTO.java
@@ -1,0 +1,26 @@
+package com.pointtils.pointtils.src.application.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactDataResponseDTO {
+
+    private UUID id;
+    private String name;
+    private String picture;
+    private String document;
+    private BigDecimal rating;
+    private List<SpecialtyResponseDTO> specialties;
+}

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/mapper/AppointmentMapper.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/mapper/AppointmentMapper.java
@@ -1,16 +1,22 @@
 package com.pointtils.pointtils.src.application.mapper;
 
 import com.pointtils.pointtils.src.application.dto.requests.AppointmentRequestDTO;
+import com.pointtils.pointtils.src.application.dto.responses.AppointmentFilterResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.AppointmentResponseDTO;
+import com.pointtils.pointtils.src.application.dto.responses.ContactDataResponseDTO;
 import com.pointtils.pointtils.src.core.domain.entities.Appointment;
 import com.pointtils.pointtils.src.core.domain.entities.Interpreter;
 import com.pointtils.pointtils.src.core.domain.entities.User;
 import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentModality;
 import com.pointtils.pointtils.src.core.domain.entities.enums.AppointmentStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AppointmentMapper {
+
+    private final UserSpecialtyMapper userSpecialtyMapper;
 
     public AppointmentRequestDTO toDTO(Appointment appointament) {
         return AppointmentRequestDTO.builder()
@@ -67,5 +73,41 @@ public class AppointmentMapper {
                 .startTime(appointment.getStartTime())
                 .endTime(appointment.getEndTime())
                 .build();
+    }
+
+    public AppointmentFilterResponseDTO toFilterResponseDTO(Appointment appointment, User user) {
+        return AppointmentFilterResponseDTO.builder()
+                .id(appointment.getId())
+                .uf(appointment.getUf())
+                .city(appointment.getCity())
+                .neighborhood(appointment.getNeighborhood())
+                .street(appointment.getStreet())
+                .streetNumber(appointment.getStreetNumber())
+                .addressDetails(appointment.getAddressDetails())
+                .modality(appointment.getModality().name())
+                .date(appointment.getDate().toString())
+                .description(appointment.getDescription())
+                .status(appointment.getStatus().name())
+                .interpreterId(appointment.getInterpreter().getId())
+                .userId(appointment.getUser().getId())
+                .startTime(appointment.getStartTime())
+                .endTime(appointment.getEndTime())
+                .contactData(toContactDataResponseDto(user))
+                .build();
+    }
+
+    private ContactDataResponseDTO toContactDataResponseDto(User user) {
+        ContactDataResponseDTO.ContactDataResponseDTOBuilder builder = ContactDataResponseDTO.builder()
+                .id(user.getId())
+                .name(user.getDisplayName())
+                .document(user.getDocument())
+                .picture(user.getPicture())
+                .specialties(userSpecialtyMapper.toDtoList(user.getSpecialties()));
+
+        if (user instanceof Interpreter interpreter) {
+            builder.rating(interpreter.getRating());
+        }
+
+        return builder.build();
     }
 }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/AppointmentService.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/AppointmentService.java
@@ -2,6 +2,7 @@ package com.pointtils.pointtils.src.application.services;
 
 import com.pointtils.pointtils.src.application.dto.requests.AppointmentPatchRequestDTO;
 import com.pointtils.pointtils.src.application.dto.requests.AppointmentRequestDTO;
+import com.pointtils.pointtils.src.application.dto.responses.AppointmentFilterResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.AppointmentResponseDTO;
 import com.pointtils.pointtils.src.application.mapper.AppointmentMapper;
 import com.pointtils.pointtils.src.core.domain.entities.Appointment;
@@ -91,7 +92,7 @@ public class AppointmentService {
     }
 
     /*Testar! */
-    public List<AppointmentResponseDTO> searchAppointments(UUID interpreterId, UUID userId, AppointmentStatus status, AppointmentModality modality, LocalDateTime fromDateTime) {
+    public List<AppointmentFilterResponseDTO> searchAppointments(UUID interpreterId, UUID userId, AppointmentStatus status, AppointmentModality modality, LocalDateTime fromDateTime) {
         List<Appointment> appointments = appointmentRepository.findAll();
 
         return appointments.stream()
@@ -100,7 +101,13 @@ public class AppointmentService {
                 .filter(appointment -> status == null || appointment.getStatus().equals(status))
                 .filter(appointment -> modality == null || appointment.getModality().equals(modality))
                 .filter(appointment -> fromDateTime == null || isAfterDateTime(appointment, fromDateTime))
-                .map(appointmentMapper::toResponseDTO)
+                .map(appointment -> {
+                    if (interpreterId != null) {
+                        return appointmentMapper.toFilterResponseDTO(appointment, appointment.getUser());
+                    } else {
+                        return appointmentMapper.toFilterResponseDTO(appointment, appointment.getInterpreter());
+                    }
+                })
                 .toList();
     }
 

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Enterprise.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Enterprise.java
@@ -30,6 +30,11 @@ public class Enterprise extends User {
     }
 
     @Override
+    public String getDocument() {
+        return cnpj;
+    }
+
+    @Override
     public UserTypeE getType() {
         return UserTypeE.ENTERPRISE;
     }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Person.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/Person.java
@@ -54,6 +54,11 @@ public class Person extends User {
     public String getDisplayName() {
         return name;
     }
+
+    @Override
+    public String getDocument() {
+        return cpf;
+    }
 }
 
 

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/User.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/User.java
@@ -77,4 +77,6 @@ public abstract class User {
     private Set<Specialty> specialties = new HashSet<>();
 
     public abstract String getDisplayName();
+
+    public abstract String getDocument();
 }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/UserSpecialtyControllerTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/UserSpecialtyControllerTest.java
@@ -64,6 +64,11 @@ class UserSpecialtyControllerTest {
             }
 
             @Override
+            public String getDocument() {
+                return "11122233344";
+            }
+
+            @Override
             public UserTypeE getType() {
                 return UserTypeE.PERSON;
             }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/AppointmentServiceTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/AppointmentServiceTest.java
@@ -2,8 +2,10 @@ package com.pointtils.pointtils.src.application.services;
 
 import com.pointtils.pointtils.src.application.dto.requests.AppointmentPatchRequestDTO;
 import com.pointtils.pointtils.src.application.dto.requests.AppointmentRequestDTO;
+import com.pointtils.pointtils.src.application.dto.responses.AppointmentFilterResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.AppointmentResponseDTO;
 import com.pointtils.pointtils.src.application.mapper.AppointmentMapper;
+import com.pointtils.pointtils.src.application.mapper.UserSpecialtyMapper;
 import com.pointtils.pointtils.src.core.domain.entities.Appointment;
 import com.pointtils.pointtils.src.core.domain.entities.Interpreter;
 import com.pointtils.pointtils.src.core.domain.entities.Person;
@@ -54,7 +56,7 @@ class AppointmentServiceTest {
     private UserRepository userRepository;
 
     @Spy
-    private AppointmentMapper appointmentMapper = new AppointmentMapper();
+    private AppointmentMapper appointmentMapper = new AppointmentMapper(new UserSpecialtyMapper());
 
     @InjectMocks
     private AppointmentService appointmentService;
@@ -283,7 +285,7 @@ class AppointmentServiceTest {
         
         LocalDateTime fromDateTime = LocalDateTime.now();
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
             interpreterId, userId, AppointmentStatus.PENDING, AppointmentModality.ONLINE, fromDateTime);
 
         assertNotNull(result);
@@ -296,7 +298,7 @@ class AppointmentServiceTest {
         List<Appointment> appointments = Arrays.asList(mockAppointment);
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
             null, null, null, null, null);
 
         assertNotNull(result);
@@ -426,7 +428,7 @@ class AppointmentServiceTest {
         List<Appointment> appointments = Arrays.asList(mockAppointment, otherAppointment);
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 interpreterId, null, null, null, null);
 
         assertNotNull(result);
@@ -459,7 +461,7 @@ class AppointmentServiceTest {
         List<Appointment> appointments = Arrays.asList(mockAppointment, otherAppointment);
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 null, userId, null, null, null);
 
         assertNotNull(result);
@@ -483,7 +485,7 @@ class AppointmentServiceTest {
         List<Appointment> appointments = Arrays.asList(mockAppointment, acceptedAppointment);
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 null, null, AppointmentStatus.PENDING, null, null);
 
         assertNotNull(result);
@@ -507,7 +509,7 @@ class AppointmentServiceTest {
         List<Appointment> appointments = Arrays.asList(mockAppointment, personallyAppointment);
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 null, null, null, AppointmentModality.ONLINE, null);
 
         assertNotNull(result);
@@ -534,7 +536,7 @@ class AppointmentServiceTest {
 
         LocalDateTime fromDateTime = LocalDateTime.now(); // Filtro para appointments após agora
 
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 null, null, null, null, fromDateTime);
 
         assertNotNull(result);
@@ -549,7 +551,7 @@ class AppointmentServiceTest {
         when(appointmentRepository.findAll()).thenReturn(appointments);
 
         UUID nonExistentId = UUID.randomUUID();
-        List<AppointmentResponseDTO> result = appointmentService.searchAppointments(
+        List<AppointmentFilterResponseDTO> result = appointmentService.searchAppointments(
                 nonExistentId, null, null, null, null);
 
         assertNotNull(result);

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/UserSpecialtyServiceTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/UserSpecialtyServiceTest.java
@@ -62,6 +62,11 @@ class UserSpecialtyServiceTest {
             }
 
             @Override
+            public String getDocument() {
+                return "11122233344";
+            }
+
+            @Override
             public UserTypeE getType() {
                 return UserTypeE.PERSON;
             }


### PR DESCRIPTION
📍 Título

Ajusta rota de filtro de appointments (/v1/appointments/filter) para retornar dados de contato do usuário intérprete ou solicitante

📌 Descrição

Se filtro de appointments for feito a partir de um parâmetro de interpreterId, os resultados do filtro retornam as informações do usuário pessoa ou empresa solicitante

Caso contrário, os resultados do filtro retornam as informações do usuário intérprete

Formato dos dados do usuário solicitante:
```json
"contact_data": {
        "id": "e6d0aa6f-8fac-4a28-b4f8-801218802e23",
        "name": "Empresa Exemplo LTDA",
        "picture": "url",
        "document": "12345678000190",
        "rating": null,
        "specialties": [
          {
            "id": "9e9a0cc0-f968-4852-9683-7fa5c138a5da",
            "name": "Guia-intérprete de Libras"
          }
        ]
      }
```

Formato dos dados do usuário intérprete:
```json
"contact_data": {
        "id": "e6d0aa6f-8fac-4a28-b4f8-801218802e23",
        "name": "Nome Mock",
        "picture": "url",
        "document": "11122233344",
        "rating": 4.8,
        "specialties": [
          {
            "id": "9e9a0cc0-f968-4852-9683-7fa5c138a5da",
            "name": "Guia-intérprete de Libras"
          }
        ]
      }
```

🛠️ O que foi feito?

-   [X] Implementação de nova funcionalidade
-   [ ] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🧪 Testes realizados:

<img width="1398" height="742" alt="image" src="https://github.com/user-attachments/assets/9bd11625-f454-4529-aa9b-de50f578bd20" />

<img width="1424" height="753" alt="image" src="https://github.com/user-attachments/assets/fed79781-3905-4e11-8468-45e8802b9cef" />

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Backend/issues/77
