### PR TITLE
Adiciona filtro por nome e fix filtro por modalidade de interpretes

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/controllers/InterpreterController.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/controllers/InterpreterController.java
@@ -1,8 +1,16 @@
 package com.pointtils.pointtils.src.application.controllers;
 
-import java.util.List;
-import java.util.UUID;
-
+import com.pointtils.pointtils.src.application.dto.requests.InterpreterBasicRequestDTO;
+import com.pointtils.pointtils.src.application.dto.requests.InterpreterPatchRequestDTO;
+import com.pointtils.pointtils.src.application.dto.responses.ApiResponse;
+import com.pointtils.pointtils.src.application.dto.responses.InterpreterListResponseDTO;
+import com.pointtils.pointtils.src.application.dto.responses.InterpreterResponseDTO;
+import com.pointtils.pointtils.src.application.services.InterpreterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,19 +25,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.pointtils.pointtils.src.application.dto.requests.InterpreterBasicRequestDTO;
-import com.pointtils.pointtils.src.application.dto.requests.InterpreterPatchRequestDTO;
-import com.pointtils.pointtils.src.application.dto.responses.ApiResponse;
-import com.pointtils.pointtils.src.application.dto.responses.InterpreterListResponseDTO;
-import com.pointtils.pointtils.src.application.dto.responses.InterpreterResponseDTO;
-import com.pointtils.pointtils.src.application.services.InterpreterService;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
-
+import java.util.List;
+import java.util.UUID;
 
 
 @RestController
@@ -60,10 +57,10 @@ public class InterpreterController {
             @RequestParam(required = false) String uf,
             @RequestParam(required = false) String neighborhood,
             @RequestParam(required = false) String specialty,
+            @RequestParam(required = false) String name,
             @RequestParam(required = false, name = "available_date") @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") String availableDate) {
-        List<InterpreterListResponseDTO> interpreters = service.findAll(
-                modality, gender, city, uf, neighborhood, specialty,
-                availableDate);
+        List<InterpreterListResponseDTO> interpreters = service.findAll(modality, gender, city, uf, neighborhood,
+                specialty, availableDate, name);
         return ResponseEntity.ok(ApiResponse.success("Intérpretes encontrados com sucesso", interpreters));
     }
 
@@ -79,7 +76,7 @@ public class InterpreterController {
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "Atualiza parcialmente um usuário intérprete por ID")
     public ResponseEntity<ApiResponse<InterpreterResponseDTO>> patchInterpreter(@PathVariable UUID id,
-            @RequestBody @Valid InterpreterPatchRequestDTO dto) {
+                                                                                @RequestBody @Valid InterpreterPatchRequestDTO dto) {
         InterpreterResponseDTO updated = service.updatePartial(id, dto);
         return ResponseEntity.ok(ApiResponse.success("Intérprete atualizado com sucesso", updated));
     }
@@ -88,7 +85,7 @@ public class InterpreterController {
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "Atualiza um usuário intérprete por ID")
     public ResponseEntity<ApiResponse<InterpreterResponseDTO>> putInterpreter(@PathVariable UUID id,
-            @RequestBody @Valid InterpreterBasicRequestDTO dto) {
+                                                                              @RequestBody @Valid InterpreterBasicRequestDTO dto) {
         InterpreterResponseDTO updated = service.updateComplete(id, dto);
         return ResponseEntity.ok(ApiResponse.success("Intérprete atualizado com sucesso", updated));
     }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/InterpreterService.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/InterpreterService.java
@@ -84,7 +84,8 @@ public class InterpreterService {
             String uf,
             String neighborhood,
             String specialty,
-            String availableDate) {
+            String availableDate,
+            String name) {
 
         InterpreterModality modalityEnum = null;
         if (modality != null) {
@@ -117,7 +118,7 @@ public class InterpreterService {
 
         return repository.findAll(
                         InterpreterSpecification.filter(modalityEnum, uf, city, neighborhood, specialtyList, genderEnum, dayOfWeek,
-                                requestedStart, requestedEnd))
+                                requestedStart, requestedEnd, name))
                 .stream()
                 .map(responseMapper::toListResponseDTO)
                 .toList();

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/infrastructure/repositories/spec/InterpreterSpecification.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/infrastructure/repositories/spec/InterpreterSpecification.java
@@ -8,6 +8,8 @@ import com.pointtils.pointtils.src.core.domain.entities.enums.DayOfWeek;
 import com.pointtils.pointtils.src.core.domain.entities.enums.Gender;
 import com.pointtils.pointtils.src.core.domain.entities.enums.InterpreterModality;
 import io.jsonwebtoken.lang.Collections;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
@@ -30,7 +32,8 @@ public class InterpreterSpecification {
             Gender gender,
             DayOfWeek dayOfWeek,
             LocalTime requestedStart,
-            LocalTime requestedEnd
+            LocalTime requestedEnd,
+            String name
     ) {
         return (root, query, cb) -> {
             query.distinct(true);
@@ -39,19 +42,18 @@ public class InterpreterSpecification {
 
             Predicate predicate = cb.conjunction();
 
-            if (modality != null) predicate = cb.and(predicate, cb.equal(root.get("modality"), modality));
+            if (modality == InterpreterModality.ALL) {
+                predicate = cb.and(predicate, root.get("modality").in(InterpreterModality.ALL, InterpreterModality.ONLINE, InterpreterModality.PERSONALLY));
+            } else if (modality != null) {
+                predicate = cb.and(predicate, root.get("modality").in(InterpreterModality.ALL, modality));
+            }
+            if (name != null) predicate = cb.and(predicate, cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
             if (gender != null) predicate = cb.and(predicate, cb.equal(root.get("gender"), gender));
             if (uf != null) predicate = cb.and(predicate, cb.equal(location.get("uf"), uf));
             if (city != null) predicate = cb.and(predicate, cb.like(cb.lower(location.get("city")), "%" + city.toLowerCase() + "%"));
             if (neighborhood != null) predicate = cb.and(predicate, cb.like(cb.lower(location.get("neighborhood")), "%" + neighborhood.toLowerCase() + "%"));
             if (!Collections.isEmpty(specialties)) {
-                Subquery<UUID> subquery = query.subquery(UUID.class);
-                var subRoot = subquery.from(UserSpecialty.class);
-                subquery.select(subRoot.get("user").get("id"))
-                        .where(subRoot.get("specialty").get("id").in(specialties))
-                        .groupBy(subRoot.get("user").get("id"))
-                        .having(cb.equal(cb.countDistinct(subRoot.get("specialty").get("id")), specialties.size()));
-
+                Subquery<UUID> subquery = buildSpecialtiesSubquery(query, specialties, cb);
                 predicate = cb.and(predicate, root.get("id").in(subquery));
             }
             if (dayOfWeek != null && requestedStart != null && requestedEnd != null) {
@@ -62,5 +64,16 @@ public class InterpreterSpecification {
 
             return predicate;
         };
+    }
+
+    private static Subquery<UUID> buildSpecialtiesSubquery(CriteriaQuery<?> query, List<UUID> specialties,
+                                                           CriteriaBuilder criteriaBuilder) {
+        Subquery<UUID> subquery = query.subquery(UUID.class);
+        var subRoot = subquery.from(UserSpecialty.class);
+        subquery.select(subRoot.get("user").get("id"))
+                .where(subRoot.get("specialty").get("id").in(specialties))
+                .groupBy(subRoot.get("user").get("id"))
+                .having(criteriaBuilder.equal(criteriaBuilder.countDistinct(subRoot.get("specialty").get("id")), specialties.size()));
+        return subquery;
     }
 }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/InterpreterControllerTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/controllers/InterpreterControllerTest.java
@@ -205,8 +205,8 @@ class InterpreterControllerTest {
     void deveBuscarInterpretesComSucesso() throws Exception {
         // Arrange
         InterpreterListResponseDTO mockResponse = createInterpreterListResponse();
-        when(interpreterService.findAll(
-                null, null, null, null, null, null, null)).thenReturn(List.of(mockResponse));
+        when(interpreterService.findAll(null, null, null, null, null, null, null, null))
+                .thenReturn(List.of(mockResponse));
 
         // Act & Assert
         mockMvc.perform(get("/v1/interpreters")

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/InterpreterServiceTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/services/InterpreterServiceTest.java
@@ -93,14 +93,7 @@ class InterpreterServiceTest {
         when(repository.findAll(any(Specification.class))).thenReturn(List.of(foundInterpreter));
         when(responseMapper.toListResponseDTO(foundInterpreter)).thenReturn(mappedResponse);
 
-        assertThat(service.findAll(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null))
+        assertThat(service.findAll(null, null, null, null, null, null, null, null))
                 .hasSize(1)
                 .contains(mappedResponse);
     }
@@ -156,7 +149,8 @@ class InterpreterServiceTest {
                 "SP",
                 "Higienópolis",
                 specialty.getId().toString(),
-                "2025-12-31 10:00"
+                "2025-12-31 10:00",
+                null
         );
 
         // Assert

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/infrastructure/repositories/spec/InterpreterSpecificationTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/infrastructure/repositories/spec/InterpreterSpecificationTest.java
@@ -1,26 +1,26 @@
 package com.pointtils.pointtils.src.infrastructure.repositories.spec;
 
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import java.time.LocalTime;
-
+import com.pointtils.pointtils.src.core.domain.entities.Interpreter;
+import com.pointtils.pointtils.src.core.domain.entities.Schedule;
 import com.pointtils.pointtils.src.core.domain.entities.enums.DayOfWeek;
-import jakarta.persistence.criteria.Path;
+import com.pointtils.pointtils.src.core.domain.entities.enums.Gender;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.domain.Specification;
 
-import com.pointtils.pointtils.src.core.domain.entities.Interpreter;
-import com.pointtils.pointtils.src.core.domain.entities.Schedule;
-import com.pointtils.pointtils.src.core.domain.entities.enums.Gender;
+import java.time.LocalTime;
 
-import jakarta.persistence.criteria.JoinType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class InterpreterSpecificationTest {
 
@@ -37,8 +37,8 @@ class InterpreterSpecificationTest {
         when(cb.equal(root.get("gender"), Gender.MALE)).thenReturn(genderPredicate);
         when(cb.and(basePredicate, genderPredicate)).thenReturn(genderPredicate);
 
-        Specification<Interpreter> spec = InterpreterSpecification.filter(
-                null, null, null, null, null, Gender.MALE, null, null, null);
+        Specification<Interpreter> spec = InterpreterSpecification.filter(null, null, null, null,
+                null, Gender.MALE, null, null, null, null);
 
         Predicate result = spec.toPredicate(root, query, cb);
 
@@ -46,7 +46,7 @@ class InterpreterSpecificationTest {
         verify(cb).equal(root.get("gender"), Gender.MALE);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     void shouldBuildPredicateWithCity() {
         Root<Interpreter> root = mock(Root.class);
@@ -67,8 +67,8 @@ class InterpreterSpecificationTest {
         when(cb.and(basePredicate, cityPredicate)).thenReturn(cityPredicate);
         when(cb.conjunction()).thenReturn(basePredicate);
 
-        Specification<Interpreter> spec = InterpreterSpecification.filter(
-                null, null, "São Paulo", null, null, null, null, null, null);
+        Specification<Interpreter> spec = InterpreterSpecification.filter(null, null, "São Paulo",
+                null, null, null, null, null, null, null);
 
         Predicate result = spec.toPredicate(root, query, cb);
 
@@ -76,8 +76,7 @@ class InterpreterSpecificationTest {
         verify(cb).like(lowerCityExpression, "%são paulo%");
     }
 
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     void shouldBuildPredicateWithScheduleAndTime() {
         Root<Interpreter> root = mock(Root.class);
@@ -104,8 +103,8 @@ class InterpreterSpecificationTest {
         when(cb.and(dayPredicate, startPredicate)).thenReturn(startPredicate);
         when(cb.and(startPredicate, endPredicate)).thenReturn(endPredicate);
 
-        Specification<Interpreter> spec = InterpreterSpecification.filter(
-                null, null, null, null, null, null, DayOfWeek.MON, requestedStart, requestedEnd);
+        Specification<Interpreter> spec = InterpreterSpecification.filter(null, null, null, null,
+                null, null, DayOfWeek.MON, requestedStart, requestedEnd, null);
 
         Predicate result = spec.toPredicate(root, query, cb);
 


### PR DESCRIPTION
📍 Título

Corrige rota de filtros do intérprete para viabilizar integração com Frontend

📌 Descrição

- Em filtro por modalidade:
  - Se parâmetro for ALL, filtra por intérpretes com qualquer modalidade
  - Se for ONLINE, filtra por intérpretes com modalidade ONLINE ou ALL
  - Se for PERSONALLY, filtra por intérpretes com modalidade PERSONALLY ou ALL
- Permite filtrar por nome

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🧪 Testes realizados:

Filtro por nome
<img width="1409" height="628" alt="image" src="https://github.com/user-attachments/assets/34ba8dc6-352b-4e2e-85cc-4e398b68d534" />
<img width="1411" height="912" alt="image" src="https://github.com/user-attachments/assets/50f25b0d-9350-4823-8244-0efce667c166" />

Filtro por modalidade
<img width="1411" height="908" alt="image" src="https://github.com/user-attachments/assets/083fa52b-736d-4ade-9d9a-f47718856fc9" />
<img width="1402" height="812" alt="image" src="https://github.com/user-attachments/assets/b6d45101-90b2-4a41-814b-621abb692bc0" />

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Frontend/issues/130