### PR TITLE
Ajusta formato de resposta de rota de filtro de interpretes

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/InterpreterListResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/InterpreterListResponseDTO.java
@@ -1,32 +1,26 @@
 package com.pointtils.pointtils.src.application.dto.responses;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pointtils.pointtils.src.application.dto.LocationDTO;
-import com.pointtils.pointtils.src.core.domain.entities.enums.InterpreterModality;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class InterpreterListResponseDTO {
+
     private UUID id;
     private String name;
-    private BigDecimal rating;
-    @JsonProperty("min_value")
-    private BigDecimal minValue;
-    @JsonProperty("max_value")
-    private BigDecimal maxValue;
-    private InterpreterModality modality;
-    private List<LocationDTO> locations;
     private String picture;
     private List<SpecialtyResponseDTO> specialties;
+    private List<LocationDTO> locations;
+    @JsonProperty("professional_data")
+    private ProfessionalDataListResponseDTO professionalData;
 }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/ProfessionalDataListResponseDTO.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/dto/responses/ProfessionalDataListResponseDTO.java
@@ -1,0 +1,23 @@
+package com.pointtils.pointtils.src.application.dto.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfessionalDataListResponseDTO {
+
+    private BigDecimal rating;
+    @JsonProperty("min_value")
+    private BigDecimal minValue;
+    @JsonProperty("max_value")
+    private BigDecimal maxValue;
+    private String modality;
+}

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/mapper/InterpreterResponseMapper.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/mapper/InterpreterResponseMapper.java
@@ -3,6 +3,7 @@ package com.pointtils.pointtils.src.application.mapper;
 import com.pointtils.pointtils.src.application.dto.LocationDTO;
 import com.pointtils.pointtils.src.application.dto.responses.InterpreterListResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.InterpreterResponseDTO;
+import com.pointtils.pointtils.src.application.dto.responses.ProfessionalDataListResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.ProfessionalDataResponseDTO;
 import com.pointtils.pointtils.src.application.util.MaskUtil;
 import com.pointtils.pointtils.src.core.domain.entities.Interpreter;
@@ -51,10 +52,6 @@ public class InterpreterResponseMapper {
         return InterpreterListResponseDTO.builder()
                 .id(interpreter.getId())
                 .name(interpreter.getName())
-                .rating(interpreter.getRating() != null ? interpreter.getRating() : BigDecimal.ZERO)
-                .minValue(interpreter.getMinValue() != null ? interpreter.getMinValue() : BigDecimal.ZERO)
-                .maxValue(interpreter.getMaxValue() != null ? interpreter.getMaxValue() : BigDecimal.ZERO)
-                .modality(interpreter.getModality())
                 .locations(interpreter.getLocations() != null
                         ? interpreter.getLocations().stream()
                         .map(locationMapper::toDto)
@@ -62,6 +59,7 @@ public class InterpreterResponseMapper {
                         : Collections.emptyList())
                 .picture(interpreter.getPicture())
                 .specialties(userSpecialtyMapper.toDtoList(interpreter.getSpecialties()))
+                .professionalData(toProfessionalDataListResponseDTO(interpreter))
                 .build();
     }
 
@@ -74,6 +72,15 @@ public class InterpreterResponseMapper {
                 .modality(interpreter.getModality() != null ? interpreter.getModality().name() : null)
                 .description(interpreter.getDescription())
                 .imageRights(interpreter.getImageRights())
+                .build();
+    }
+
+    private ProfessionalDataListResponseDTO toProfessionalDataListResponseDTO(Interpreter interpreter) {
+        return ProfessionalDataListResponseDTO.builder()
+                .rating(interpreter.getRating() != null ? interpreter.getRating() : BigDecimal.ZERO)
+                .minValue(interpreter.getMinValue())
+                .maxValue(interpreter.getMaxValue())
+                .modality(interpreter.getModality() != null ? interpreter.getModality().name() : null)
                 .build();
     }
 }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/application/mapper/InterpreterResponseMapperTest.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/application/mapper/InterpreterResponseMapperTest.java
@@ -113,10 +113,10 @@ class InterpreterResponseMapperTest {
         // Assert
         assertThat(listResponseDTO.getId()).isEqualTo(id);
         assertThat(listResponseDTO.getName()).isEqualTo("John Doe");
-        assertThat(listResponseDTO.getRating()).isEqualTo(BigDecimal.valueOf(4.5));
-        assertThat(listResponseDTO.getMinValue()).isEqualTo(BigDecimal.valueOf(100));
-        assertThat(listResponseDTO.getMaxValue()).isEqualTo(BigDecimal.valueOf(200));
-        assertThat(listResponseDTO.getModality()).isEqualTo(InterpreterModality.ONLINE);
+        assertThat(listResponseDTO.getProfessionalData().getRating()).isEqualTo(BigDecimal.valueOf(4.5));
+        assertThat(listResponseDTO.getProfessionalData().getMinValue()).isEqualTo(BigDecimal.valueOf(100));
+        assertThat(listResponseDTO.getProfessionalData().getMaxValue()).isEqualTo(BigDecimal.valueOf(200));
+        assertThat(listResponseDTO.getProfessionalData().getModality()).isEqualTo(InterpreterModality.ONLINE.name());
         assertThat(listResponseDTO.getPicture()).isEqualTo("profile.jpg");
         assertThat(listResponseDTO.getLocations()).hasSize(1);
     }

--- a/pointtils/src/test/java/com/pointtils/pointtils/src/util/TestDataUtil.java
+++ b/pointtils/src/test/java/com/pointtils/pointtils/src/util/TestDataUtil.java
@@ -12,6 +12,7 @@ import com.pointtils.pointtils.src.application.dto.requests.ProfessionalDataPatc
 import com.pointtils.pointtils.src.application.dto.responses.InterpreterListResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.InterpreterResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.PersonResponseDTO;
+import com.pointtils.pointtils.src.application.dto.responses.ProfessionalDataListResponseDTO;
 import com.pointtils.pointtils.src.application.dto.responses.ProfessionalDataResponseDTO;
 import com.pointtils.pointtils.src.core.domain.entities.enums.Gender;
 import com.pointtils.pointtils.src.core.domain.entities.enums.InterpreterModality;
@@ -131,15 +132,19 @@ public class TestDataUtil {
     }
 
     public static InterpreterListResponseDTO createInterpreterListResponse() {
+        ProfessionalDataListResponseDTO professionalInfo = ProfessionalDataListResponseDTO.builder()
+                .rating(new BigDecimal("0.0"))
+                .minValue(new BigDecimal("100.00"))
+                .maxValue(new BigDecimal("500.00"))
+                .modality("presencial")
+                .build();
+
         return InterpreterListResponseDTO.builder()
                 .id(UUID.randomUUID())
                 .name("João Intérprete")
-                .rating(BigDecimal.ZERO)
-                .minValue(BigDecimal.ZERO)
-                .maxValue(BigDecimal.ZERO)
-                .modality(InterpreterModality.ALL)
                 .locations(List.of(new LocationDTO(UUID.randomUUID(), "RS", "Porto Alegre", "São João")))
                 .picture("picture_url")
+                .professionalData(professionalInfo)
                 .build();
     }
 


### PR DESCRIPTION
📍 Título

Corrige formato de resposta de rota de filtro de intérpretes para que siga o mesmo padrão de rota de busca de intérprete por ID, com dados profissionais dentro de "profissional_data"

📌 Descrição

```json
{
  "success": true,
  "message": "Intérpretes encontrados com sucesso",
  "data": [
    {
      "id": "176c2a9e-e458-43a8-8316-a15119511a14",
      "name": "Maria Souza",
      "picture": null,
      "specialties": [
        {
          "id": "f960f5b0-be40-4bff-8625-84fbe6e86588",
          "name": "Intérprete de Libras"
        },
        {
          "id": "9e9a0cc0-f968-4852-9683-7fa5c138a5da",
          "name": "Guia-intérprete de Libras"
        }
      ],
      "locations": [
        {
          "id": "1312e5e1-68a5-4aec-a58b-be75cdaf5f13",
          "uf": "MG",
          "city": "Belo Horizonte",
          "neighborhood": "Anchieta"
        }
      ],
      "professional_data": {
        "rating": 4.8,
        "modality": "ONLINE",
        "min_value": 100,
        "max_value": 300
      }
    }
  ]
}
```

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🧪 Testes realizados:

<img width="1417" height="898" alt="image" src="https://github.com/user-attachments/assets/84ed8be4-8d16-4d6a-9917-c87c201bcc7a" />

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Frontend/issues/130