### PR TITLE
Corrige automação para envio de notificações de deadline no Discord

### DIFF
--- a/scripts/check_deadlines.py
+++ b/scripts/check_deadlines.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 import requests
@@ -29,6 +30,7 @@ HEADERS = {
 }
 
 GRAPHQL_URL = "https://api.github.com/graphql"
+BATCH_SIZE = 4
 
 def run_graphql(query, variables=None):
     response = requests.post(GRAPHQL_URL, json={"query": query, "variables": variables}, headers=HEADERS)
@@ -149,7 +151,7 @@ def get_project_items(project_id):
 def notify_discord(overdue_issues):
     if not overdue_issues:
         return
-    for i in range(0, len(overdue_issues), 4):
+    for i in range(0, len(overdue_issues), BATCH_SIZE):
         if i == 0:
             content = "**⚠️ Algumas tarefas estão com o prazo de entrega atrasado. Saberiam dizer quando conseguirão finalizar?**\n"
         else:
@@ -160,7 +162,7 @@ def notify_discord(overdue_issues):
     
         response = requests.post(DISCORD_WEBHOOK_URL, json={"content": content})
         if (response.status_code < 200 or response.status_code >= 300):
-            print("Error sending notification to Discord:", response.json())
+            logging.error("Error sending notification to Discord:", response.json())
         response.raise_for_status()
 
 def validate_env():


### PR DESCRIPTION
📍 Título

Quebra envio de notificacoes de deadline em múltiplas mensagens para não dar erro 400

📌 Descrição

A automação estava falhando em duas situações:
- Quando existiam issues sem tipo
- Quando o tamanho da mensagem enviada para o Discord excedia 2000 - erro 400 com corpo de resposta {'content': ['Must be 2000 or fewer in length.']}

Este MR visa corrigir estes 2 pontos, para que issues sem tipo não sejam consideradas e para que mensagens grandes sejam quebradas em múltiplas mensagens menores

Além disso, se adicionou um print para facilitar o debug em caso de novos erros ocorrerem no futuro

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🔍 Arquivos novos/modificados?

path: ` scripts/check_deadlines.py`

🧪 Testes realizados:

<img width="1136" height="547" alt="image" src="https://github.com/user-attachments/assets/a72b09bd-165b-4afa-9cc3-b583a1927407" />

✅ Checklist

-   [ ] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto
