### PR TITLE
fix: corrigir tagging e rollback para imagens Grafana e Prometheus

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -263,10 +263,21 @@ jobs:
           
           if [ -n "$PROMETHEUS_IMAGE_ID" ]; then
             echo "Tagging and pushing Prometheus image..."
+            
+            # PRIMEIRO: Salvar a imagem atual como "previous" ANTES de sobrescrever com a nova
+            echo "Salvando imagem atual do Prometheus como previous..."
+            docker pull $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:${{ env.PROMETHEUS_IMAGE_TAG }} || echo "Imagem atual do Prometheus não encontrada, pulando backup"
+            docker tag $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:${{ env.PROMETHEUS_IMAGE_TAG }} $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:previous || echo "Não foi possível salvar imagem anterior do Prometheus"
+            
+            # DEPOIS: Tag e push da NOVA imagem
             docker tag $PROMETHEUS_IMAGE_ID $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:$IMAGE_TAG
             docker tag $PROMETHEUS_IMAGE_ID $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:${{ env.PROMETHEUS_IMAGE_TAG }}
             docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:$IMAGE_TAG
             docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:${{ env.PROMETHEUS_IMAGE_TAG }}
+            
+            # FINALMENTE: Push da imagem "previous" (se existir)
+            docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:previous || echo "Não foi possível fazer push da imagem previous do Prometheus"
+            
             echo "prometheus_image=$ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:$IMAGE_TAG" >> $GITHUB_OUTPUT
           else
             echo "⚠️ AVISO: Não foi possível encontrar a imagem do Prometheus para tagging"
@@ -280,10 +291,21 @@ jobs:
           
           if [ -n "$GRAFANA_IMAGE_ID" ]; then
             echo "Tagging and pushing Grafana image..."
+            
+            # PRIMEIRO: Salvar a imagem atual como "previous" ANTES de sobrescrever com a nova
+            echo "Salvando imagem atual do Grafana como previous..."
+            docker pull $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:${{ env.GRAFANA_IMAGE_TAG }} || echo "Imagem atual do Grafana não encontrada, pulando backup"
+            docker tag $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:${{ env.GRAFANA_IMAGE_TAG }} $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:previous || echo "Não foi possível salvar imagem anterior do Grafana"
+            
+            # DEPOIS: Tag e push da NOVA imagem
             docker tag $GRAFANA_IMAGE_ID $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:$IMAGE_TAG
             docker tag $GRAFANA_IMAGE_ID $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:${{ env.GRAFANA_IMAGE_TAG }}
             docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:$IMAGE_TAG
             docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:${{ env.GRAFANA_IMAGE_TAG }}
+            
+            # FINALMENTE: Push da imagem "previous" (se existir)
+            docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:previous || echo "Não foi possível fazer push da imagem previous do Grafana"
+            
             echo "grafana_image=$ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:$IMAGE_TAG" >> $GITHUB_OUTPUT
           else
             echo "⚠️ AVISO: Não foi possível encontrar a imagem do Grafana para tagging"


### PR DESCRIPTION
# 📍 Corrigir tagging e rollback para imagens Grafana e Prometheus

**Tags:** #pipeline #deploy #rollback #monitoring #fix

## 📌 Descrição

Este PR corrige problemas críticos no pipeline de deploy para desenvolvimento que impediam o rollback automático dos serviços de monitoramento (Grafana e Prometheus). As imagens desses serviços não estavam sendo tageadas corretamente para a tag `previous`, o que impedia o sistema de rollback de funcionar completamente.

## 🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [x] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

## 🔍 Arquivos novos/modificados?

path: `.github/workflows/deploy-to-dev.yml`
path: `terraform-dev/rollback-dev-app.sh`

## 🧪 Testes realizados:

- ✅ Verificação do estado atual da instância EC2 (3.13.243.58)
- ✅ Confirmação de que o rollback foi executado automaticamente
- ✅ Validação de que todos os containers estão rodando corretamente
- ✅ Teste de health check da aplicação (HTTP 200)
- ✅ Verificação de que o dashboard PointTils está carregado no Grafana
- ✅ Confirmação de que o Prometheus está coletando métricas

## 👀 Problemas conhecidos:

Nenhum problema conhecido após as correções. O sistema de deploy e rollback agora funciona completamente para todos os componentes.

## 📷 Anexos

### Antes da correção:
O pipeline tageava apenas aplicação e banco para `previous`:
```yaml
# Apenas para app e db
docker tag $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:${{ env.APP_IMAGE_TAG }} $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:previous
```

### Depois da correção:
O pipeline agora tageia TODOS os serviços para `previous`:
```yaml
# Para Prometheus
docker tag $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:${{ env.PROMETHEUS_IMAGE_TAG }} $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-prometheus:previous

# Para Grafana  
docker tag $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:${{ env.GRAFANA_IMAGE_TAG }} $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}-grafana:previous
```

### Script de rollback atualizado:
```bash
# Agora inclui monitoramento
PROMETHEUS_IMAGE="$ECR_REGISTRY/pointtils-dev-prometheus:$ROLLBACK_TAG"
GRAFANA_IMAGE="$ECR_REGISTRY/pointtils-dev-grafana:$ROLLBACK_TAG"

# Verificação e reinicialização de todos os serviços
docker stop pointtils-dev pointtils-db-dev prometheus grafana
docker rm pointtils-dev pointtils-db-dev prometheus grafana
```

## ✅ Checklist

-   [x] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [x] O código segue os padrões do projeto

## 📎 Referências

- **Issue relacionada:** Análise do deploy da branch `update-dockerfile-dash-copy`
- **URLs de acesso:**
  - Aplicação: http://3.13.243.58:8080
  - Grafana: http://3.13.243.58:3000 (admin/admin123456)
  - Prometheus: http://3.13.243.58:9090
  - Dashboard PointTils: http://3.13.243.58:3000/d/pointtils-dashboard/pointtils-dashboard-de-performance
