### PR TITLE
fix: corrige conflito de containers no deploy

### DIFF
--- a/terraform/deploy-app.sh
+++ b/terraform/deploy-app.sh
@@ -38,10 +38,10 @@ docker pull $GRAFANA_IMAGE
 echo "Criando rede Docker pointtils-network se não existir..."
 docker network create pointtils-network 2>/dev/null || true
 
-# Parar e remover containers existentes
-echo "Parando containers existentes..."
-docker stop pointtils pointtils-db prometheus grafana 2>/dev/null || true
-docker rm pointtils pointtils-db prometheus grafana 2>/dev/null || true
+# Parar e remover containers existentes de forma mais robusta
+echo "Parando e removendo containers existentes..."
+docker stop pointtils pointtils-db prometheus grafana backend-pointtils backend-pointtils-db backend-prometheus backend-grafana 2>/dev/null || true
+docker rm pointtils pointtils-db prometheus grafana backend-pointtils backend-pointtils-db backend-prometheus backend-grafana 2>/dev/null || true
 
 # Remover forçadamente se ainda existirem
 echo "Removendo forçadamente se containers ainda existirem..."
@@ -49,6 +49,18 @@ docker rm -f pointtils 2>/dev/null || true
 docker rm -f pointtils-db 2>/dev/null || true
 docker rm -f prometheus 2>/dev/null || true
 docker rm -f grafana 2>/dev/null || true
+docker rm -f backend-pointtils 2>/dev/null || true
+docker rm -f backend-pointtils-db 2>/dev/null || true
+docker rm -f backend-prometheus 2>/dev/null || true
+docker rm -f backend-grafana 2>/dev/null || true
+
+# Remover containers por filtro para garantir que todos sejam removidos
+echo "Removendo containers por filtro..."
+docker ps -a --filter "name=pointtils" --filter "name=backend" --filter "name=prometheus" --filter "name=grafana" --format "{{.Names}}" | xargs -r docker rm -f 2>/dev/null || true
+
+# Listar containers ativos para debug
+echo "Listando containers ativos após remoção:"
+docker ps -a --filter "name=pointtils" --filter "name=backend" --filter "name=prometheus" --filter "name=grafana"
 
 # Criar volumes se não existirem
 echo "Criando volumes se não existirem..."


### PR DESCRIPTION
📌 __Descrição__

Este PR corrige um problema crítico no pipeline de deploy que impedia a execução bem-sucedida devido a conflitos de nomes de containers Docker. O erro "container name is already in use" ocorria quando containers existentes não eram completamente removidos antes de tentar iniciar novos containers com os mesmos nomes.

🛠️ __O que foi feito?__

- [x] Implementação de nova funcionalidade
- [x] Correção de bug
- [ ] Refatoração de código
- [ ] Atualização de documentação

🔍 __Arquivos novos/modificados?__

path: `terraform/deploy-app.sh`

🧪 __Testes realizados:__

- Análise do log completo do erro no pipeline de produção
- Verificação do comportamento atual do script de deploy
- Implementação de remoção robusta de containers com múltiplas abordagens

👀 __Problemas conhecidos:__

- O pipeline anterior falhava consistentemente com erro de conflito de containers
- Containers com nomes alternativos não eram removidos adequadamente
- O rollback automático também sofria do mesmo problema

📷 __Anexos__

__Antes:__

```bash
# Remoção limitada de containers
docker stop pointtils pointtils-db prometheus grafana
docker rm pointtils pointtils-db prometheus grafana
```

__Depois:__

```bash
# Remoção robusta de containers
docker stop pointtils pointtils-db prometheus grafana backend-pointtils backend-pointtils-db backend-prometheus backend-grafana
docker rm pointtils pointtils-db prometheus grafana backend-pointtils backend-pointtils-db backend-prometheus backend-grafana
docker ps -a --filter "name=pointtils" --filter "name=backend" --filter "name=prometheus" --filter "name=grafana" --format "{{.Names}}" | xargs -r docker rm -f
```

✅ __Checklist__

- [ ] Testes foram adicionados/atualizados
- [ ] Documentação foi atualizada (se necessário)
- [x] O código segue os padrões do projeto

📎 __Referências__

- Erro original no pipeline: `docker: Error response from daemon: Conflict. The container name "/***" is already in use by container "11ccfa8880880bad4f6a3b265de91c3f8b34b9c567a88b009da95da2470d08f9"`
- Commit da correção: `75135a7`
- Branch: `dev`
