### PR TITLE
Corrige filtro de time slots disponíveis para considerar apenas appointments confimados

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/infrastructure/repositories/ScheduleRepository.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/infrastructure/repositories/ScheduleRepository.java
@@ -76,6 +76,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, UUID>, JpaSp
                     FROM appointment a
                     WHERE a.interpreter_id = sd.interpreter_id
                       AND a.date = sd.selected_date
+                      AND a.status IN ('ACCEPTED', 'COMPLETED')
                       AND ('2000-01-01'::timestamp + a.start_time) < gs.slot_start + interval '30 minutes'
                       AND ('2000-01-01'::timestamp + a.end_time) > gs.slot_start
                 )


### PR DESCRIPTION
…ppointments confirmados ou encerrados

📍 Título

Corrige filtro de time slots disponíveis para considerar apenas appointments confimados

📌 Descrição

Atualmente, na API GET /v1/schedules/available, retorna-se os time slots ocupados caso exista algum Appointment no horário, independente do status. Assim, por exemplo, se um appointment for cancelado, aquele intervalo de horário continua sendo apresentado como ocupado para o intérprete, o que está incorreto

Ajustar esta rota para considerar apenas appointments de status COMPLETED ou ACCEPTED

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🧪 Testes realizados:

<img width="1651" height="34" alt="image" src="https://github.com/user-attachments/assets/3b96c45e-45f4-448c-9a67-c8264578127c" />

<img width="1430" height="849" alt="image" src="https://github.com/user-attachments/assets/805a7f1a-b83a-41fc-bbf2-90b6711d225e" />

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [X] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Backend/issues/213