### PR TITLE
Ajusta envio de mensagens do Firebase para que sejam do tipo notificacao

### DIFF
--- a/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/NotificationService.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/application/services/NotificationService.java
@@ -1,9 +1,14 @@
 package com.pointtils.pointtils.src.application.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import com.pointtils.pointtils.src.core.domain.entities.enums.NotificationType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.TaskScheduler;
@@ -11,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Slf4j
@@ -21,14 +25,16 @@ public class NotificationService {
 
     private static final String ZONE_ID = "America/Sao_Paulo";
     private final UserAppService userAppService;
+    private final ParametersService parametersService;
     private final TaskScheduler notificationTaskScheduler;
+    private final ObjectMapper objectMapper;
 
     public void sendNotificationToUser(UUID userId, NotificationType type) {
         var userApps = userAppService.getUserAppsByUserId(userId);
         for (var app : userApps) {
             try {
                 sendNotification(app.getToken(), type);
-            } catch (FirebaseMessagingException ex) {
+            } catch (Exception ex) {
                 log.error("Erro ao enviar notificação {} para o usuário {} e dispositivo {}",
                         type.name(), userId, app.getDeviceId(), ex);
             }
@@ -45,12 +51,33 @@ public class NotificationService {
     }
 
     private void sendNotification(String token, NotificationType type) throws FirebaseMessagingException {
+        ObjectNode notificationContent = getNotificationContent(type);
         Message message = Message.builder()
                 .setToken(token)
-                .putData("type", type.name())
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(notificationContent.get("title").asText())
+                                .setBody(notificationContent.get("body").asText())
+                                .build()
+                )
                 .build();
 
         String response = FirebaseMessaging.getInstance().send(message);
         log.info("Notificação {} enviada com sucesso - resposta: {}", type.name(), response);
+    }
+
+    private ObjectNode getNotificationContent(NotificationType type) {
+        String key = switch (type) {
+            case APPOINTMENT_REQUESTED -> "NOTIFICATION_APPOINTMENT_REQUESTED";
+            case APPOINTMENT_ACCEPTED -> "NOTIFICATION_APPOINTMENT_ACCEPTED";
+            case APPOINTMENT_CANCELED -> "NOTIFICATION_APPOINTMENT_CANCELED";
+            case APPOINTMENT_REMINDER -> "NOTIFICATION_APPOINTMENT_REMINDER";
+        };
+        try {
+            var foundParameter = parametersService.findByKey(key);
+            return (ObjectNode) objectMapper.readTree(foundParameter.getValue());
+        } catch (EntityNotFoundException | ClassCastException | JsonProcessingException ex) {
+            return objectMapper.createObjectNode();
+        }
     }
 }

--- a/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/enums/NotificationType.java
+++ b/pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/enums/NotificationType.java
@@ -1,8 +1,8 @@
 package com.pointtils.pointtils.src.core.domain.entities.enums;
 
 public enum NotificationType {
-    APPOINTMENT_ACCEPTED,
     APPOINTMENT_REQUESTED,
+    APPOINTMENT_ACCEPTED,
     APPOINTMENT_CANCELED,
     APPOINTMENT_REMINDER
 }

--- a/pointtils/src/main/resources/db/migration/V25__Add_push_notifications_content.sql
+++ b/pointtils/src/main/resources/db/migration/V25__Add_push_notifications_content.sql
@@ -1,0 +1,8 @@
+-- Adiciona titulo e corpo de notificacoes push de agendamentos na tabela de parametros
+
+INSERT INTO parameters (id, key, value) VALUES
+(uuid_generate_v4(), 'NOTIFICATION_APPOINTMENT_REQUESTED', '{"title":"Você recebeu uma nova solicitação!","body":"Alguém acabou de pedir sua ajuda como intérprete."}'),
+(uuid_generate_v4(), 'NOTIFICATION_APPOINTMENT_CANCELED', '{"title":"Status da solicitação atualizado","body":"Uma solicitação foi cancelada ou recusada."}'),
+(uuid_generate_v4(), 'NOTIFICATION_APPOINTMENT_ACCEPTED', '{"title":"Sua solicitação foi aceita!","body":"Boas notícias! O intérprete aceitou sua solicitação."}'),
+(uuid_generate_v4(), 'NOTIFICATION_APPOINTMENT_REMINDER', '{"title":"Lembrete para você!","body":"Seu agendamento está chegando. Não esqueça!"}'),
+(uuid_generate_v4(), 'NOTIFICATION_DEFAULT', '{"title":"Nova notificação","body":"Você recebeu uma atualização importante. Clique para mais detalhes."}');


### PR DESCRIPTION
📍 Título

Ajusta envio de mensagens do Firebase para que sejam do tipo notificacao

📌 Descrição

Para que notificações do Firebase Cloud Messaging sejam exibidas mesmo quando o aplicativo estiver fechado, é necessário que o backend envie as mensagens como uma notificação, e não como uma _data message_.

Assim, este PR visa corrigir esse envio da mensagem, armazenando o título e corpo de cada notificação no banco de dados, na tabela `parameters`.

🛠️ O que foi feito?

-   [ ] Implementação de nova funcionalidade
-   [X] Correção de bug
-   [ ] Refatoração de código
-   [ ] Atualização de documentação

🔍 Arquivos novos/modificados?

path: ` pointtils/src/main/java/com/pointtils/pointtils/src/application/services/NotificationService.java`
path: ` pointtils/src/main/java/com/pointtils/pointtils/src/core/domain/entities/enums/NotificationType.java`
path: ` pointtils/src/test/java/com/pointtils/pointtils/src/application/services/NotificationServiceTest.java`
path: ` pointtils/src/main/resources/db/migration/V25__Add_push_notifications_content.sql`

🧪 Testes realizados: serão executados pelo frontend

✅ Checklist

-   [X] Testes foram adicionados/atualizados
-   [ ] Documentação foi atualizada (se necessário)
-   [ ] O código segue os padrões do projeto

📎 Referências

https://github.com/PointTils/Backend/issues/151